### PR TITLE
Add CPU wakelocks on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="wakelock.wakelock">
 
-    <!-- <uses-permission android:name="android.permission.WAKE_LOCK" /> -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>


### PR DESCRIPTION
This would resolve #1.  

The necessary documentation can be [found on Android Developers](https://developer.android.com/training/scheduling/wakelock#cpu).

Current unresolved questions are:

 1. Does adding the `android.permission.WAKE_LOCK` permission to the Android Manifest of the plugin work or do users need to add it to their own project?

 1. Is it even possible to run Flutter code when the screen is turned off (without any additional plugin)?

To properly test this, #5 should be fixed first.
