### PR TITLE
Clarify permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         device:
-          - 'iPhone 11 Pro Max (14.0)'
+          - 'iPhone 12 Pro Max (14.2)'
         channel:
           # Do not check stable until NNBD is on stable.
           #- 'stable'

--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0-nullsafety.2
+
+* Indicated that no permissions are required for using the `wakelock` plugin in the README.
+
 ## 0.3.0-nullsafety.1
 
 * Fixed `UIImagePickerController` disabling the wakelock (using the camera on iOS).

--- a/wakelock/README.md
+++ b/wakelock/README.md
@@ -13,6 +13,9 @@ Essentially, this allows you to keep the device awake, i.e. prevent the device f
 
 To use this plugin, follow the [installing guide](https://pub.dev/packages/wakelock/install).
 
+The `wakelock` plugin **does not require any special *permissions*** on any platform :)  
+This is because it only enables the *screen wakelock* and not any partial (CPU) wakelocks that would keep the app alive in the background.
+
 ### Implementation
 
 Everything in this plugin is controlled via the [`Wakelock` class](https://pub.dev/documentation/wakelock/latest/wakelock/Wakelock-class.html).  

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, and web.
-version: 0.3.0-nullsafety.1
+version: 0.3.0-nullsafety.2
 homepage: https://github.com/creativecreatorormaybenot/wakelock/tree/master/wakelock
 
 environment:


### PR DESCRIPTION
## Description

Clarifies that no permissions are required for using `wakelock`.

Resolves #70.