### PR TITLE
Switch to license action v2

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: FantasticFiasco/action-update-license-year@66564cc720675678f03c008d254ebbf5f22609ac
+    - uses: FantasticFiasco/action-update-license-year@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: '**/LICENSE'


### PR DESCRIPTION
## Description

Switches to the v2 of the license action.

See https://github.com/FantasticFiasco/action-update-license-year/issues/122.
