### PR TITLE
Added macOS support

### DIFF
--- a/wakelock_macos/.gitignore
+++ b/wakelock_macos/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.dart_tool/
+
+.packages
+.pub/
+
+build/

--- a/wakelock_macos/CHANGELOG.md
+++ b/wakelock_macos/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.2.0-nullsafety.0
+
+* Initial release

--- a/wakelock_macos/LICENSE
+++ b/wakelock_macos/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2020-2021, creativecreatorormaybenot
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/wakelock_macos/README.md
+++ b/wakelock_macos/README.md
@@ -1,0 +1,10 @@
+# wakelock_web [![Pub version](https://img.shields.io/pub/v/wakelock_platform_interface.svg)](https://pub.dev/packages/wakelock_web) [![GitHub stars](https://img.shields.io/github/stars/creativecreatorormaybenot/wakelock.svg)](https://github.com/creativecreatorormaybenot/wakelock) [![Twitter Follow](https://img.shields.io/twitter/follow/creativemaybeno?label=Follow&style=social)](https://twitter.com/creativemaybeno)
+
+macOS platform implementation of the `wakelock_platform_interface` for the 
+[wakelock plugin][wakelock GitHub].
+
+## Getting started
+
+If you want to use the wakelock plugin on macOS, see the [main `wakelock` plugin package](https://pub.dev/packages/wakelock).
+
+[wakelock GitHub]: https://github.com/creativecreatorormaybenot/wakelock

--- a/wakelock_macos/lib/wakelock_macos.dart
+++ b/wakelock_macos/lib/wakelock_macos.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:wakelock_platform_interface/wakelock_platform_interface.dart';
+
+class WakelockMacos extends WakelockPlatformInterface {
+  static const MethodChannel _channel = const MethodChannel('wakelock_macos');
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    await _channel.invokeMethod('toggle', <String, dynamic>{
+      'enable': enable,
+    });
+  }
+
+  @override
+  Future<bool> get enabled async {
+    final enabled = await _channel.invokeMethod('enabled');
+    return enabled;
+  }
+}

--- a/wakelock_macos/macos/Classes/WakelockMacosPlugin.swift
+++ b/wakelock_macos/macos/Classes/WakelockMacosPlugin.swift
@@ -1,0 +1,47 @@
+import Cocoa
+import FlutterMacOS
+import IOKit.pwr_mgt
+
+public class WakelockMacosPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "wakelock_macos", binaryMessenger: registrar.messenger)
+    let instance = WakelockMacosPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+  
+  var assertionID: IOPMAssertionID = 0
+  var wakelockEnabled = false
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "toggle":
+    let args = call.arguments as? Dictionary<String, Any>
+    let enable = args!["enable"] as! Bool
+    if(enable){
+      enableWakelock()
+    }else {
+      disableWakelock();
+    }
+    result(true)
+    case "enabled":
+      result(wakelockEnabled)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  func enableWakelock(reason: String = "Disabling Screen Sleep") {
+    if(!wakelockEnabled){
+      wakelockEnabled = IOPMAssertionCreateWithName( kIOPMAssertionTypeNoDisplaySleep as CFString,
+                                       IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                                       reason as CFString,
+                                       &assertionID) == kIOReturnSuccess
+    }
+  }
+
+func disableWakelock() {
+    if wakelockEnabled {
+        IOPMAssertionRelease(assertionID)
+        wakelockEnabled = false
+    }
+  }
+}

--- a/wakelock_macos/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/wakelock_macos/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,0 +1,12 @@
+//
+//  Generated file. Do not edit.
+//
+
+import FlutterMacOS
+import Foundation
+
+import wakelock_macos
+
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  WakelockMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockMacosPlugin"))
+}

--- a/wakelock_macos/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
+++ b/wakelock_macos/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
@@ -1,0 +1,11 @@
+// This is a generated file; do not edit or check into version control.
+FLUTTER_ROOT=/Users/wilson/Developer/flutter
+FLUTTER_APPLICATION_PATH=/Users/wilson/Flutter Projects/wakelock/wakelock_macos
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=0.2.0.0
+FLUTTER_BUILD_NUMBER=0.2.0.0
+EXCLUDED_ARCHS=arm64
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=false
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.packages

--- a/wakelock_macos/macos/Flutter/ephemeral/flutter_export_environment.sh
+++ b/wakelock_macos/macos/Flutter/ephemeral/flutter_export_environment.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/wilson/Developer/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/wilson/Flutter Projects/wakelock/wakelock_macos"
+export "FLUTTER_BUILD_DIR=build"
+export "FLUTTER_BUILD_NAME=0.2.0.0"
+export "FLUTTER_BUILD_NUMBER=0.2.0.0"
+export "EXCLUDED_ARCHS=arm64"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=false"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.packages"

--- a/wakelock_macos/macos/wakelock_macos.podspec
+++ b/wakelock_macos/macos/wakelock_macos.podspec
@@ -1,0 +1,22 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint wakelock_macos.podspec' to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'wakelock'
+  s.version          = '0.0.1'
+  s.summary          = 'Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on Android, iOS, macOS, and web.'
+  s.description      = <<-DESC
+Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on Android, iOS, macOS, and web.
+                       DESC
+  s.homepage         = 'http://example.com'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Your Company' => 'email@example.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '8.0'
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+end

--- a/wakelock_macos/pubspec.yaml
+++ b/wakelock_macos/pubspec.yaml
@@ -1,0 +1,32 @@
+name: wakelock_macos
+description: macOS platform implementation of the wakelock_platform_interface for the wakelock plugin.
+version: 0.2.0-nullsafety.0
+homepage: https://github.com/creativecreatorormaybenot/wakelock/tree/master/wakelock_macos
+
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+  flutter: '>=1.24.0-0 <2.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
+
+  wakelock_platform_interface: ^0.2.0-nullsafety.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+  pedantic: ^1.10.0-nullsafety.0
+  
+  wakelock:
+    path: ../wakelock
+
+flutter:
+  plugin:
+    platforms:
+      macos:
+        pluginClass: WakelockMacosPlugin
+        fileName: wakelock_macos.dart

--- a/wakelock_macos/test/wakelock_macos_test.dart
+++ b/wakelock_macos/test/wakelock_macos_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('wakelock_macos');
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return '42';
+    });
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+}


### PR DESCRIPTION
Addresses #78 

Using the `IOKit.pwr_mgt` framework on macOS, I've added macOS support.
I extended the `WakelockPlatformInterface` to implement all necessary methods.

Since there is no system API to get the status of the wakelock, its state is tracked by a boolean:
```swift
 var wakelockEnabled = false
```
Calling the `enabled` method simply returns this boolean.
```swift
case "enabled":
      result(wakelockEnabled)
```
Once the application is killed, the wakelock is automatically disabled.