### PR TITLE
Publish Windows implementation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,12 +17,10 @@ on:
 jobs:
   analyze:
     timeout-minutes: 7
-    runs-on: ${{ matrix.os }}
-    name: Analysis of ${{ matrix.package }} (${{ matrix.channel }}; ${{ matrix.os }})
+    runs-on: ubuntu-latest
+    name: ${{ matrix.package }} analysis on ${{ matrix.channel }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
         channel:
           - 'stable'
           - 'beta'
@@ -51,7 +49,7 @@ jobs:
   test:
     timeout-minutes: 14
     runs-on: macos-latest
-    name: Testing of ${{ matrix.package }} (${{ matrix.channel }})
+    name: ${{ matrix.package }} testing on ${{ matrix.channel }}
     strategy:
       matrix:
         device:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,8 +24,7 @@ jobs:
         os:
           - ubuntu-latest
         channel:
-          # Do not check stable until NNBD is on stable.
-          #- 'stable'
+          - 'stable'
           - 'beta'
           - 'dev'
         package:
@@ -33,6 +32,7 @@ jobs:
           - 'wakelock_macos'
           - 'wakelock_platform_interface'
           - 'wakelock_web'
+          - 'wakelock_windows'
       fail-fast: false
 
     steps:
@@ -57,8 +57,7 @@ jobs:
         device:
           - 'iPhone 12 Pro Max (14.2)'
         channel:
-          # Do not check stable until NNBD is on stable.
-          #- 'stable'
+          - 'stable'
           - 'beta'
           - 'dev'
         package:
@@ -67,6 +66,7 @@ jobs:
           - 'wakelock_platform_interface'
           # Web tests do not work for now.
           # - 'wakelock_web'
+          - 'wakelock_windows'
       fail-fast: false
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   analyze:
-    timeout-minutes: 7
+    timeout-minutes: 11
     runs-on: ubuntu-latest
     name: ${{ matrix.package }} analysis on ${{ matrix.channel }}
     strategy:
@@ -47,13 +47,13 @@ jobs:
         working-directory: ${{ matrix.package }}
 
   test:
-    timeout-minutes: 14
+    timeout-minutes: 16
     runs-on: macos-latest
     name: ${{ matrix.package }} testing on ${{ matrix.channel }}
     strategy:
       matrix:
         device:
-          - 'iPhone 12 Pro Max (14.2)'
+          - 'iPhone 12 Pro Max (14.4)'
         channel:
           - 'stable'
           - 'beta'

--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -18,7 +18,7 @@ jobs:
   configure:
     timeout-minutes: 9
     runs-on: ubuntu-latest
-    name: Configuration of ${{ matrix.package }}
+    name: ${{ matrix.package }} configuration
     strategy:
       matrix:
         package:

--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -26,6 +26,7 @@ jobs:
           - 'wakelock_macos'
           - 'wakelock_platform_interface'
           - 'wakelock_web'
+          - 'wakelock_windows'
       fail-fast: false
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
           - 'wakelock_macos'
           - 'wakelock_platform_interface'
           - 'wakelock_web'
+          - 'wakelock_windows'
       fail-fast: false
 
     steps:
@@ -38,6 +39,7 @@ jobs:
           - 'wakelock_macos'
           - 'wakelock_platform_interface'
           - 'wakelock_web'
+          - 'wakelock_windows'
       fail-fast: false
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   pana:
     timeout-minutes: 9
     runs-on: ubuntu-latest
-    name: Configuration of ${{ matrix.package }}
+    name: ${{ matrix.package }} configuration
     strategy:
       matrix:
         package:
@@ -31,7 +31,7 @@ jobs:
     needs: pana
     timeout-minutes: 4
     runs-on: ubuntu-latest
-    name: Publishing of ${{ matrix.package }}
+    name: ${{ matrix.package }} publishing
     strategy:
       matrix:
         package:

--- a/wakelock/example/lib/main.dart
+++ b/wakelock/example/lib/main.dart
@@ -7,7 +7,7 @@ void main() {
 
 /// Example app widget demonstrating how to use the wakelock plugin.
 ///
-/// The example implementation is located inside [OutlineButton.onPressed]
+/// The example implementation is located inside [OutlinedButton.onPressed]
 /// callback functions and a [FutureBuilder].
 class WakelockExampleApp extends StatefulWidget {
   @override
@@ -29,7 +29,7 @@ class _WakelockExampleAppState extends State<WakelockExampleApp> {
               const Spacer(
                 flex: 3,
               ),
-              OutlineButton(
+              OutlinedButton(
                 onPressed: () {
                   // The following code will enable the wakelock on the device
                   // using the wakelock plugin.
@@ -41,7 +41,7 @@ class _WakelockExampleAppState extends State<WakelockExampleApp> {
                 child: const Text('enable wakelock'),
               ),
               const Spacer(),
-              OutlineButton(
+              OutlinedButton(
                 onPressed: () {
                   // The following code will disable the wakelock on the device
                   // using the wakelock plugin.

--- a/wakelock/example/pubspec.yaml
+++ b/wakelock/example/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
   integration_test: ^1.0.1
   test: any
 
-  pedantic: ^1.10.0
+  pedantic: ^1.11.0
 
 dependency_overrides:
   # We override the platform dependencies of wakelock here because we use the example app for
@@ -40,9 +40,9 @@ dependency_overrides:
   # current platform implementations.
   wakelock_macos:
     path: ../../wakelock_macos
-  wakelock_windows:
-    path: ../../wakelock_windows
   wakelock_platform_interface:
     path: ../../wakelock_platform_interface
   wakelock_web:
     path: ../../wakelock_web
+  wakelock_windows:
+    path: ../../wakelock_windows

--- a/wakelock/lib/wakelock.dart
+++ b/wakelock/lib/wakelock.dart
@@ -21,10 +21,12 @@ var wakelockPlatformInstance = !kIsWeb &&
         // on web.
         Platform.isMacOS
     ? WakelockMacOS()
-        // This doesn't feel like the correct way to assign the windows implementation,
-        // but platform channels aren't used due to the win32 package.
-        // See this issue for details: https://github.com/flutter/flutter/issues/52267.
-    : (!kIsWeb && Platform.isWindows ? WakelockWindows() : WakelockPlatformInterface.instance);
+    // This doesn't feel like the correct way to assign the windows implementation,
+    // but platform channels aren't used due to the win32 package.
+    // See this issue for details: https://github.com/flutter/flutter/issues/52267.
+    : (!kIsWeb && Platform.isWindows
+        ? WakelockWindows()
+        : WakelockPlatformInterface.instance);
 
 /// Class providing all wakelock functionality using static members.
 ///

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: ^1.10.0
+  pedantic: ^1.11.0
   pigeon: ^0.1.15
 
 flutter:

--- a/wakelock_macos/pubspec.yaml
+++ b/wakelock_macos/pubspec.yaml
@@ -1,5 +1,6 @@
 name: wakelock_macos
-description: macOS platform implementation of the wakelock_platform_interface for the wakelock plugin.
+description: >-2
+  macOS platform implementation of the wakelock_platform_interface for the wakelock plugin.
 version: 0.1.0
 homepage: https://github.com/creativecreatorormaybenot/wakelock/tree/master/wakelock_macos
 
@@ -19,10 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: ^1.10.0
-  
-  wakelock:
-    path: ../wakelock
+  pedantic: ^1.11.0
 
 flutter:
   plugin:

--- a/wakelock_platform_interface/pubspec.yaml
+++ b/wakelock_platform_interface/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: ^1.10.0
+  pedantic: ^1.11.0

--- a/wakelock_web/pubspec.yaml
+++ b/wakelock_web/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: ^1.10.0
+  pedantic: ^1.11.0
 
   wakelock:
     path: ../wakelock

--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [0.1.0]
+## 0.1.0
 
 * Initial release

--- a/wakelock_windows/LICENSE
+++ b/wakelock_windows/LICENSE
@@ -1,21 +1,21 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2021, creativecreatorormaybenot
+Copyright (c) 2021, creativecreatorormaybenot
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
+   list of conditions and the following disclaimer.
 
 2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 3. Neither the name of the copyright holder nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wakelock_windows/README.md
+++ b/wakelock_windows/README.md
@@ -1,4 +1,4 @@
-# wakelock_windows
+# wakelock_windows [![Pub version](https://img.shields.io/pub/v/wakelock_windows.svg)](https://pub.dev/packages/wakelock_windows) [![GitHub stars](https://img.shields.io/github/stars/creativecreatorormaybenot/wakelock.svg)](https://github.com/creativecreatorormaybenot/wakelock) [![Twitter Follow](https://img.shields.io/twitter/follow/creativemaybeno?label=Follow&style=social)](https://twitter.com/creativemaybeno)
 
 Windows platform implementation of the `wakelock_platform_interface` for the
 [wakelock plugin][wakelock GitHub].

--- a/wakelock_windows/README.md
+++ b/wakelock_windows/README.md
@@ -5,8 +5,14 @@ Windows platform implementation of the `wakelock_platform_interface` for the
 
 ## Getting started
 
-If you want to use the wakelock plugin on Windows, see the [main `wakelock` plugin package](https://pub.dev/packages/wakelock).
+If you want to use the wakelock plugin on Windows, see the
+[main `wakelock` plugin package][wakelock Pub].
 
 ## Implementation
 
-Note that the implementation does not use a `MethodChannel` implementation as relies on the win32 package.
+Note that the implementation does not use a `MethodChannel` implementation as it relies on the
+[win32 package][win32 Pub].
+
+[wakelock GitHub]: https://github.com/creativecreatorormaybenot/wakelock
+[wakelock Pub]: https://pub.dev/packages/wakelock
+[win32 Pub]: https://pub.dev/packages/win32

--- a/wakelock_windows/analysis_options.yaml
+++ b/wakelock_windows/analysis_options.yaml
@@ -1,9 +1,0 @@
-include: package:pedantic/analysis_options.yaml
-
-linter:
-  rules:
-    - public_member_api_docs
-
-analyzer:
-  errors:
-    public_member_api_docs: warning

--- a/wakelock_windows/lib/wakelock_windows.dart
+++ b/wakelock_windows/lib/wakelock_windows.dart
@@ -3,37 +3,42 @@ import 'dart:async';
 import 'package:wakelock_platform_interface/wakelock_platform_interface.dart';
 import 'package:win32/win32.dart';
 
+/// Informs the system that the state being set should remain in effect until
+/// the next call that uses ES_CONTINUOUS and one of the other state flags is
+/// cleared.
+///
+/// See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate#parameters.
 const _ES_CONTINUOUS = 0x80000000;
+
+/// Forces the display to be on by resetting the display idle timer.
+///
+/// See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate#parameters.
 const _ES_DISPLAY_REQUIRED = 0x00000002;
 
-
-/// The windows implementation of the [WakelockPlatformInterface].
+/// The Windows implementation of the [WakelockPlatformInterface].
 ///
-/// This class implements the `wakelock` plugin functionality for windows using
-/// SetThreadExecutionState from win32 api.
-///
-/// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate#parameters
-///
+/// This class implements the `wakelock` plugin functionality for Windows using
+/// the `SetThreadExecutionState` win32 API (see https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate).
 class WakelockWindows extends WakelockPlatformInterface {
-  bool _isEnabled = false;
+  var _enabled = false;
 
   @override
   Future<void> toggle({required bool enable}) async {
-    int response;
+    final int response;
     if (enable) {
       response = SetThreadExecutionState(_ES_CONTINUOUS | _ES_DISPLAY_REQUIRED);
     } else {
       response = SetThreadExecutionState(_ES_CONTINUOUS);
     }
 
-    // SetThreadExecutionState returns 0 if the operation failed
+    // SetThreadExecutionState returns 0 if the operation failed.
     if (response != 0) {
-      _isEnabled = enable;
+      _enabled = enable;
     }
   }
 
   @override
-  Future<bool> get enabled async => _isEnabled;
+  Future<bool> get enabled async => _enabled;
 
   @override
   bool get isMock => false;

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -1,14 +1,16 @@
 name: wakelock_windows
-description: Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
+description: >-2
+  Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
 version: 0.1.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=2.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
+
   wakelock_platform_interface: ^0.2.0
   win32: ^2.0.0
 
@@ -16,4 +18,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: ^1.10.0
+  pedantic: ^1.11.0
+
+# todo: use dartPluginClass declaration once that lands on stable (https://github.com/flutter/flutter/issues/52267_

--- a/wakelock_windows/test/wakelock_windows_test.dart
+++ b/wakelock_windows/test/wakelock_windows_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // There are currently no unit tests for the Windows implementation as
+  // testing for Windows is currently done using the integration tests in
+  // wakelock/example.
+  // This means that every change to the wakelock_windows package should be
+  // tested using a local dependency in the wakelock example integration test
+  // before being published. For that, we use dependency overrides in the
+  // example app.
+  test('stub', () {
+    final acceptUnitTestingDefeat = true;
+    expect(acceptUnitTestingDefeat, isTrue);
+  });
+}


### PR DESCRIPTION
## Description

Follows up on #96 by publishing `wakelock_windows`.

This does not yet integrate Windows support. In another PR after this, Windows support will be added to `wakelock` itself.
