### PR TITLE
Add mavenCentral to Gradle build

### DIFF
--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Add mavenCentral to Gradle build.
+
 ## 0.5.3
 
 * Removed Jcenter from Gradle build as has been sunset.

--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.5.4
+## 0.5.3+1
 
-* Add mavenCentral to Gradle build.
+* Addded mavenCentral to Gradle build.
 
 ## 0.5.3
 

--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,6 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
+        mavenCentral()
     }
 }
 

--- a/wakelock/example/android/build.gradle
+++ b/wakelock/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/wakelock/example/android/build.gradle
+++ b/wakelock/example/android/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
     }
 }
 

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, and web.
-version: 0.5.3
+version: 0.5.4
 homepage: https://github.com/creativecreatorormaybenot/wakelock/tree/master/wakelock
 
 environment:

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, and web.
-version: 0.5.4
+version: 0.5.3+1
 homepage: https://github.com/creativecreatorormaybenot/wakelock/tree/master/wakelock
 
 environment:


### PR DESCRIPTION
In order to build an android project correctly, you must not just remove Jcenter, but add mavenCentral instead, otherwise the following error will occur:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':wakelock'.
> Could not resolve all artifacts for configuration ':wakelock:classpath'.
   > Could not find org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.3.50/kotlin-gradle-plugin-1.3.50.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :wakelock
```

@grahamsmith