### PR TITLE
Change Kotlin version to 1.5.10

### DIFF
--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -2,7 +2,7 @@ group 'creativemaybeno.wakelock'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Description

I had to change Kotlin version to 1.5.10 in the build.gradle file for the Android implementation as it had conflicts with some other packages that use newer versions of Kotlin.

Already tested with my app and it works fine.
