### PR TITLE
Recommend to not call `Wakelock.enable()` inside of `main()`

### DIFF
--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+2
+
+* Documented the recommendation of not calling `Wakelock.enable()` directly inside of `main()`.
+
 ## 0.6.1+1
 
 * Documented necessity of ensuring that the `WidgetsBinding` is initialized.

--- a/wakelock/README.md
+++ b/wakelock/README.md
@@ -86,6 +86,23 @@ In general, it is advisable to make your wakelock dependent on certain component
 instead, e.g. by only enabling it (continually) when a certain widget is visible.
 There is no negative impact in calling `Wakelock.enable()` more often.
 
+### Calling `Wakelock.enable()` in `main()`
+
+As touched on in the previous paragraph, calling `Wakelock.enable()` in your `main()` function is
+not the best approach for a number of reasons.
+
+The most important factors are:
+
+1. Users expect their screen to automatically turn off unless e.g. a video is playing.  
+   It is unlikely that your whole app requires the screen to always stay on.
+2. The wakelock can be released by external sources at any time (e.g. by the OS).  
+   Only calling `Wakelock.enable()` once will most likely mean that the screen turns off at one
+   point or another anyway.
+
+This is why you should instead prefer to enable the wakelock whenever components inside of your app
+that require the screen to stay on are active. This can e.g. happen in the `build` method of your
+widget.
+
 ## Learn more
 
 If you want to learn more about how this plugin works, how to contribute, etc., you can read through

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, and web.
-version: 0.6.1+1
+version: 0.6.1+2
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock
 
 environment:


### PR DESCRIPTION
## Description

cc @nilsreichardt

I hope that the two sections are not contradictory now. There might still be cases where someone might want to do this.
