### PR TITLE
Fixing android build problem on Flutter 2.10

### DIFF
--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Fixed Android build issues.
+
 ## 0.6.1+2
 
 * Documented the recommendation of not calling `Wakelock.enable()` directly inside of `main()`.

--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -2,7 +2,7 @@ group 'creativemaybeno.wakelock'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, and web.
-version: 0.6.1+2
+version: 0.6.2
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock
 
 environment:


### PR DESCRIPTION
## Description

Flutter 2.10 [added support for foldable Android devices](https://docs.flutter.dev/release/breaking-changes/kotlin-version), and it relies on Android SDK API version 31's [AndroidX library](https://developer.android.com/jetpack/androidx) dependency of: `androidx.window:window-java:1.0.0`

The build fails because this new AndroidX dependency requires Android compileSdkVersion of 31 or higher.
```bash
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':wakelock:checkDebugAndroidTestAarMetadata'.
> Multiple task action failures occurred:
   > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
      > The minCompileSdk (31) specified in a
        dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
        is greater than this module's compileSdkVersion (android-29).
        Dependency: androidx.window:window-java:1.0.0-beta04.
        AAR metadata file: /home/circleci/.gradle/caches/transforms-3/2e49bf5320b03587958ef76824ad50b9/transformed/jetified-window-java-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
      > The minCompileSdk (31) specified in a
        dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
        is greater than this module's compileSdkVersion (android-29).
        Dependency: androidx.window:window:1.0.0-beta04.
        AAR metadata file: /home/circleci/.gradle/caches/transforms-3/b4515d5f332e057eb16b3d70b87c97b1/transformed/jetified-window-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.
```

[Example of a package updating it to fix android build](https://github.com/flutter-mapbox-gl/maps/pull/904)
[Example of Stack Overflow Question around the problem](https://stackoverflow.com/questions/71273382/flutter-build-failed-after-flutter-upgrade-to-2-10)
