### PR TITLE
Fix the main branch name in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The following steps are based on a version of [flutter/plugin's contributing gui
 ### Create pull requests
 
 - Fetch the latest repo state: `git fetch upstream`
-- Create a feature branch: `git checkout upstream/master -b <name_of_your_branch>`
+- Create a feature branch: `git checkout upstream/main -b <name_of_your_branch>`
 - Now, you can change the code necessary for your patch.
 
   Make sure that you bump the version in [`pubspec.yaml`][pubspec]. You **must** bump the Pubspec


### PR DESCRIPTION
## Description

Documentation is using master as the main branch name which isn't true anymore.
