### PR TITLE
Bump win32 version

### DIFF
--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.1
 
-* Increase version for win32 dependency from 2 to 3
+* Bumped the `win32` dependency from `^2.0.0` to `^3.0.0`.
 
 ## 0.2.0
 

--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Increase version for win32 dependency from 2 to 3
+
 ## 0.2.0
 
 * Bumped to depend on latest platform interface.

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wakelock_windows
 description: >-2
   Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock_windows
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^2.0.0
+  win32: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Bump win32 version to ^3.0.0

I hope this fixes #180 and prevents fetching old 0.4.0 version as described in #179
