### PR TITLE
Add support for Gradle 8.0 and update win32

### DIFF
--- a/wakelock/CHANGELOG.md
+++ b/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Add compatibility with AGP 8 (Android Gradle Plugin).
+
 ## 0.6.2
 
 * Fixed Android build issues.

--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'creativemaybeno.wakelock'
+    }
+
     compileSdkVersion 31
 
     sourceSets {

--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -2,14 +2,14 @@ group 'creativemaybeno.wakelock'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/wakelock/android/build.gradle
+++ b/wakelock/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -35,16 +35,20 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
         minSdkVersion 16
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/wakelock/example/android/.gitignore
+++ b/wakelock/example/android/.gitignore
@@ -9,3 +9,5 @@ GeneratedPluginRegistrant.java
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
 key.properties
+**/*.keystore
+**/*.jks

--- a/wakelock/example/android/app/build.gradle
+++ b/wakelock/example/android/app/build.gradle
@@ -26,13 +26,15 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'creativemaybeno.wakelock_example'
+
     compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-
-    lintOptions {
+    
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/wakelock/example/android/app/build.gradle
+++ b/wakelock/example/android/app/build.gradle
@@ -28,7 +28,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'creativemaybeno.wakelock_example'
 
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -42,7 +42,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "creativemaybeno.wakelock_example"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/wakelock/example/android/app/src/debug/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="creativemaybeno.wakelock_example">
-    <!-- Flutter needs it to communicate with the running application
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/wakelock/example/android/app/src/debug/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="creativemaybeno.wakelock_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/wakelock/example/android/app/src/main/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/main/AndroidManifest.xml
@@ -1,16 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="creativemaybeno.wakelock_example">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
-    <application
-        android:name="${applicationName}"
+   <application
         android:label="wakelock_example"
+        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
-            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/wakelock/example/android/app/src/main/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="creativemaybeno.wakelock_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="wakelock_example"
         android:name="${applicationName}"

--- a/wakelock/example/android/app/src/main/kotlin/creativemaybeno/wakelock_example/MainActivity.kt
+++ b/wakelock/example/android/app/src/main/kotlin/creativemaybeno/wakelock_example/MainActivity.kt
@@ -1,0 +1,6 @@
+package creativemaybeno.wakelock_example
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity() {
+}

--- a/wakelock/example/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/wakelock/example/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Modify this file to customize your launch splash screen -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="?android:colorBackground" />
+
+    <!-- You can insert your own image assets here -->
+    <!-- <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@mipmap/launch_image" />
+    </item> -->
+</layer-list>

--- a/wakelock/example/android/app/src/main/res/values-night/styles.xml
+++ b/wakelock/example/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/wakelock/example/android/app/src/profile/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/profile/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="creativemaybeno.wakelock_example">
-    <!-- Flutter needs it to communicate with the running application
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/wakelock/example/android/app/src/profile/AndroidManifest.xml
+++ b/wakelock/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="creativemaybeno.wakelock_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/wakelock/example/android/build.gradle
+++ b/wakelock/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/wakelock/example/android/build.gradle
+++ b/wakelock/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
         mavenCentral()

--- a/wakelock/example/android/build.gradle
+++ b/wakelock/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/wakelock/example/android/gradle.properties
+++ b/wakelock/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/wakelock/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/wakelock/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, and web.
-version: 0.6.2
+version: 0.6.3
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock
 
 environment:

--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Bumped the `win32` dependency from `^3.0.0` to `^4.0.0`.
+
 ## 0.2.1
 
 * Bumped the `win32` dependency from `^2.0.0` to `^3.0.0`.

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wakelock_windows
 description: >-2
   Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock_windows
 
 environment:

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  win32: ^4.1.3
 
 dev_dependencies:
   flutter_test:

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,10 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^4.0.0
+
+  # win32 is compatible across v4 and v5 for Win32 only (not COM)
+  # Source: https://github.com/fluttercommunity/plus_plugins/pull/1805
+  win32: ">=4.0.0 <6.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^4.1.3
+  win32: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Hello, currently the plugin doesn't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.

* I recreated the Android example project with current Flutter project structure.
* I included the namespace property with backwards compatibility
* I bumped the win32 depedency to v4 (which is 4 months old)
