### PR TITLE
Allow use of win32 4.x

### DIFF
--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  win32: ">=3.0.0 <5.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Expands the allowed range of win32 plugin as this plugin uses nothing that was affected by the breaking changes.