### PR TITLE
Upgrade win32

### DIFF
--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: >=4.0.0 <6.0.0
+  win32: ">=4.0.0 <6.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  win32: >=4.0.0 <6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Bumps the `win32` dependency, as done in plus plugins [here](https://github.com/fluttercommunity/plus_plugins/pull/1805).

Without this bump, the package is not compatible with the latest plus plugins.