### PR TITLE
Win32 version update to ^5.0.9

### DIFF
--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   wakelock_macos: ^0.4.0
   wakelock_platform_interface: ^0.3.0
   wakelock_web: ^0.4.0
-  wakelock_windows: ^0.2.0
+  wakelock_windows: ^0.2.2
 
 dev_dependencies:
   flutter_test:

--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Bumped the `win32` dependency from `^3.0.0` to `^5.0.9`.
+* 
 ## 0.2.1
 
 * Bumped the `win32` dependency from `^2.0.0` to `^3.0.0`.

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wakelock_windows
 description: >-2
   Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock_windows
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  win32: ^5.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

*Win32 version updated to ^5.0.9. The old version leads to conflicts.*

`Because wakelock_windows >=0.2.1 depends on win32 ^3.0.0 and wakelock_windows <0.2.1 depends on win32 ^2.0.0, every version of wakelock_windows requires win32 ^2.0.0 or ^3.0.0.
And because wakelock >=0.5.6 depends on wakelock_windows ^0.2.0 and package_info_plus 4.1.0 depends on win32 >=4.0.0 <6.0.0, wakelock >=0.5.6 is incompatible with package_info_plus 4.1.0.
So, because flutter_example_packages depends on both package_info_plus 4.1.0 and wakelock ^0.6.2, version solving failed.
`
