### PR TITLE
Updating win32 version to latest to make wakelock compatable with other packages

### DIFF
--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  win32: ^5.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

wakelock was not compatible with other packages because of win32 version in wakelock_windows,
Updated it to latest version, to remove conflict with other packages. 
 I was getting this error
```
Resolving dependencies...
Because no versions of wakelock_windows match >0.2.1 <0.3.0 and wakelock_windows <0.2.1 depends on win32 ^2.0.0, wakelock_windows <0.2.1-∞ or >0.2.1 <0.3.0 requires win32 ^2.0.0.
And because wakelock_windows 0.2.1 depends on win32 ^3.0.0 and share_plus >=7.0.1 depends on win32 >=4.0.0 <6.0.0, share_plus >=7.0.1 is incompatible with wakelock_windows <0.3.0.
And because wakelock 0.6.2 depends on wakelock_windows ^0.2.0 and no versions of wakelock match >0.6.2 <0.7.0, share_plus >=7.0.1 is incompatible with wakelock ^0.6.2.
So, because test depends on both wakelock ^0.6.2 and share_plus ^7.2.0, version solving failed.
```
